### PR TITLE
alias: fix man alias by moving 'command' to start

### DIFF
--- a/modules/alias.zsh
+++ b/modules/alias.zsh
@@ -54,13 +54,13 @@ alias weather='() {curl "wttr.in/$1"}' # print weather forecast for current loca
 
 # colorized man
 function man {
-  env \
+  command env \
     LESS_TERMCAP_md=$(printf "${fg_bold[green]}") \
     LESS_TERMCAP_us=$(printf "${fg[cyan]}") \
     LESS_TERMCAP_ue=$(printf "$reset_color") \
     PAGER="${commands[less]:-$PAGER}" \
     _NROFF_U=1 \
-  command man $@
+  man $@
 }
 
 # colorized diff


### PR DESCRIPTION
With the current setup, executing 'man' fails with the following error:

env: ‘command’: No such file or directory
✖ 127

Move 'command' in alias to the beginning of the function for the fix.